### PR TITLE
Json rpc http

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,8 @@
         "hyperf/redis": "^2,2",
         "hyperf/di": "^2.2",
         "hyperf/grpc-client": "^2.2",
+        "hyperf/rpc-client": "^2.2",
+        "hyperf/json-rpc": "^2.2",
         "ext-openssl": "Required to use HTTPS.",
         "ext-pdo": "Required to use MySQL Client.",
         "ext-pdo_mysql": "Required to use MySQL Client.",

--- a/src/Api/JsonRpcHttpApi.php
+++ b/src/Api/JsonRpcHttpApi.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace DtmClient\Api;
+
+use DtmClient\Constants\Operation;
+use DtmClient\Constants\Protocol;
+use DtmClient\Constants\Result;
+use DtmClient\Exception\FailureException;
+use DtmClient\Exception\GenerateException;
+use DtmClient\Exception\OngingException;
+use DtmClient\Exception\RequestException;
+use DtmClient\Exception\UnsupportedException;
+use DtmClient\JsonRpc\DtmPatchGenerator;
+use DtmClient\TransContext;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\RequestOptions;
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\JsonRpc\DataFormatter;
+use Hyperf\JsonRpc\JsonRpcHttpTransporter;
+use Hyperf\JsonRpc\PathGenerator;
+use Hyperf\Rpc\ProtocolManager;
+use Hyperf\RpcClient\AbstractServiceClient;
+use Hyperf\Utils\Packer\JsonPacker;
+use Psr\Container\ContainerInterface;
+
+class JsonRpcHttpApi extends AbstractServiceClient implements ApiInterface
+{
+    protected $serviceName = 'dtmserver';
+    
+    protected $protocol = 'jsonrpc-http';
+
+    protected ConfigInterface $config;
+
+
+    public function __construct(ContainerInterface $container, DtmPatchGenerator $patchGenerator)
+    {
+        parent::__construct($container);
+
+        $this->pathGenerator = $patchGenerator;
+        $this->config = $container->get(ConfigInterface::class);
+    }
+
+    public function getProtocol(): string
+    {
+        return Protocol::JSONRPC_HTTP;
+    }
+
+    public function generateGid(): string
+    {
+        $res = $this->__request('NewGid', []);
+        return $res['gid'];
+    }
+
+    public function prepare(array $body)
+    {
+        return $this->__request('Prepare', $body);
+    }
+
+    public function submit(array $body)
+    {
+        return $this->__request('Submit', $body);
+    }
+
+    public function abort(array $body)
+    {
+        return $this->__request('Abort', $body);
+    }
+
+    public function registerBranch(array $body)
+    {
+        return $this->__request('RegisterBranch', $body);
+    }
+
+    public function query(array $body)
+    {
+        throw new UnsupportedException('Unsupported Query operation');
+    }
+
+    public function queryAll(array $body)
+    {
+        throw new UnsupportedException('Unsupported Query operation');
+    }
+
+    public function getClient(): Client
+    {
+        return $this->client;
+    }
+
+    public function setClient(Client $client): static
+    {
+        $this->client = $client;
+        return $this;
+    }
+
+    public function transRequestBranch(RequestBranch $requestBranch)
+    {
+        $dtm = $this->config->get('dtm.server', '127.0.0.1') . ':' . $this->config->get('dtm.port.http', 36789) . '/api/dtmsvr';
+        $response = $this->client->request($requestBranch->method, $requestBranch->url, [
+            RequestOptions::QUERY => [
+                [
+                    'dtm' => $dtm,
+                    'gid' => TransContext::getGid(),
+                    'branch_id' => $requestBranch->branchId,
+                    'trans_type' => TransContext::getTransType(),
+                    'op' => $requestBranch->op,
+                ],
+            ],
+            RequestOptions::JSON => $requestBranch->body,
+            RequestOptions::HEADERS => $requestBranch->branchHeaders,
+        ]);
+        
+        
+        $this->__request($requestBranch->method, [
+            RequestOptions::QUERY => [
+                [
+                    'dtm' => $dtm,
+                    'gid' => TransContext::getGid(),
+                    'branch_id' => $requestBranch->branchId,
+                    'trans_type' => TransContext::getTransType(),
+                    'op' => $requestBranch->op,
+                ],
+            ],
+            RequestOptions::BODY => $requestBranch->body,
+        ]);
+
+        if (Result::isOngoing($response)) {
+            throw new OngingException();
+        }
+        if (Result::isFailure($response)) {
+            throw new FailureException();
+        }
+        if (! Result::isSuccess($response)) {
+            throw new RequestException($response->getReasonPhrase(), $response->getStatusCode());
+        }
+
+        return $response;
+    }
+}

--- a/src/Api/RequestBranch.php
+++ b/src/Api/RequestBranch.php
@@ -32,4 +32,8 @@ class RequestBranch
     public array $grpcDeserialize = [GPBEmpty::class, 'decode'];
 
     public array $grpcOptions = [];
+
+    public string $jsonRpcServiceName = '';
+
+    public array $jsonRpcServiceParams = [];
 }

--- a/src/ApiFactory.php
+++ b/src/ApiFactory.php
@@ -11,6 +11,7 @@ namespace DtmClient;
 use DtmClient\Api\ApiInterface;
 use DtmClient\Api\GrpcApi;
 use DtmClient\Api\HttpApi;
+use DtmClient\Api\JsonRpcHttpApi;
 use DtmClient\Constants\Protocol;
 use DtmClient\Exception\UnsupportedException;
 use Hyperf\Contract\ConfigInterface;
@@ -26,6 +27,8 @@ class ApiFactory
                 return $container->get(HttpApi::class);
             case Protocol::GRPC:
                 return $container->get(GrpcApi::class);
+            case Protocol::JSONRPC_HTTP:
+                return $container->get(JsonRpcHttpApi::class);
             default:
                 throw new UnsupportedException();
         }

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -15,6 +15,12 @@ use DtmClient\DbTransaction\DBTransactionInterface;
 use DtmClient\DbTransaction\HyperfDbTransaction;
 use DtmClient\Grpc\GrpcClientManager;
 use DtmClient\Grpc\GrpcClientManagerFactory;
+use Hyperf\Utils\Serializer\SerializerFactory;
+use Hyperf\Utils\Serializer\Serializer;
+use Hyperf\JsonRpc\JsonRpcPoolTransporter;
+use Hyperf\JsonRpc\JsonRpcTransporter;
+use Hyperf\Rpc\Contract\PathGeneratorInterface;
+use DtmClient\JsonRpc\DtmPatchGenerator;
 
 class ConfigProvider
 {
@@ -35,6 +41,9 @@ class ConfigProvider
                 ApiInterface::class => ApiFactory::class,
                 GrpcClientManager::class => GrpcClientManagerFactory::class,
                 DBTransactionInterface::class => HyperfDbTransaction::class,
+//                Hyperf\Contract\NormalizerInterface::class => new SerializerFactory(Serializer::class),
+                PathGeneratorInterface::class => DtmPatchGenerator::class,
+                JsonRpcTransporter::class => JsonRpcPoolTransporter::class,
             ],
             'commands' => [
             ],

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -15,12 +15,12 @@ use DtmClient\DbTransaction\DBTransactionInterface;
 use DtmClient\DbTransaction\HyperfDbTransaction;
 use DtmClient\Grpc\GrpcClientManager;
 use DtmClient\Grpc\GrpcClientManagerFactory;
-use Hyperf\Utils\Serializer\SerializerFactory;
-use Hyperf\Utils\Serializer\Serializer;
+use DtmClient\JsonRpc\DtmPatchGenerator;
 use Hyperf\JsonRpc\JsonRpcPoolTransporter;
 use Hyperf\JsonRpc\JsonRpcTransporter;
 use Hyperf\Rpc\Contract\PathGeneratorInterface;
-use DtmClient\JsonRpc\DtmPatchGenerator;
+use Hyperf\Utils\Serializer\Serializer;
+use Hyperf\Utils\Serializer\SerializerFactory;
 
 class ConfigProvider
 {
@@ -41,7 +41,7 @@ class ConfigProvider
                 ApiInterface::class => ApiFactory::class,
                 GrpcClientManager::class => GrpcClientManagerFactory::class,
                 DBTransactionInterface::class => HyperfDbTransaction::class,
-//                Hyperf\Contract\NormalizerInterface::class => new SerializerFactory(Serializer::class),
+                //                Hyperf\Contract\NormalizerInterface::class => new SerializerFactory(Serializer::class),
                 PathGeneratorInterface::class => DtmPatchGenerator::class,
                 JsonRpcTransporter::class => JsonRpcPoolTransporter::class,
             ],

--- a/src/Constants/Protocol.php
+++ b/src/Constants/Protocol.php
@@ -13,4 +13,6 @@ class Protocol
     public const HTTP = 'http';
 
     public const GRPC = 'grpc';
+    
+    public const JSONRPC_HTTP = 'jsonrpc-http';
 }

--- a/src/Constants/Protocol.php
+++ b/src/Constants/Protocol.php
@@ -13,6 +13,6 @@ class Protocol
     public const HTTP = 'http';
 
     public const GRPC = 'grpc';
-    
+
     public const JSONRPC_HTTP = 'jsonrpc-http';
 }

--- a/src/Constants/Result.php
+++ b/src/Constants/Result.php
@@ -32,23 +32,41 @@ class Result
 
     public const ERR_DUPLICATED_STATUS = 425;
 
-    public static function isOngoing(ResponseInterface $response)
+    public static function isOngoing(ResponseInterface|array $response)
     {
+        if (is_array($response)) {
+            if (isset($response['error'])) {
+                return $response['error']['code'] === self::ONGOING_STATUS;
+            }
+            return false;
+        }
         return $response->getStatusCode() === self::ONGOING_STATUS;
     }
 
-    public static function isSuccess(ResponseInterface $response)
+    public static function isSuccess(ResponseInterface|array $response)
     {
+        if (is_array($response)) {
+            return isset($response['result']) && ! isset($response['error']);
+        }
         return $response->getStatusCode() === self::SUCCESS_STATUS;
     }
 
-    public static function isFailure(ResponseInterface $response)
+    public static function isFailure(ResponseInterface|array $response)
     {
+        if (is_array($response)) {
+            if (isset($response['error'])) {
+                return $response['error']['code'] === self::FAILURE_STATUS;
+            }
+            return false;
+        }
         return $response->getStatusCode() === self::FAILURE_STATUS;
     }
 
-    public static function isErrDuplicated(ResponseInterface $response)
+    public static function isErrDuplicated(ResponseInterface|array $response)
     {
+        if (is_array($response) && isset($response['error'])) {
+            return $response['error']['code'] === self::ERR_DUPLICATED_STATUS;
+        }
         return $response->getStatusCode() === self::ERR_DUPLICATED_STATUS;
     }
 }

--- a/src/JsonRpc/DtmPatchGenerator.php
+++ b/src/JsonRpc/DtmPatchGenerator.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace DtmClient\JsonRpc;
+
+use Hyperf\Rpc\Contract\PathGeneratorInterface;
+
+class DtmPatchGenerator implements PathGeneratorInterface
+{
+    public function generate(string $service, string $method): string
+    {
+        var_dump($service, $method);
+        var_dump('DtmPatchGenerator::generate');
+        var_dump('---------------');
+        return sprintf('%s.%s', $service, $method);
+    }
+}

--- a/src/JsonRpc/DtmPatchGenerator.php
+++ b/src/JsonRpc/DtmPatchGenerator.php
@@ -1,5 +1,11 @@
 <?php
 
+declare(strict_types=1);
+/**
+ * This file is part of DTM-PHP.
+ *
+ * @license  https://github.com/dtm-php/dtm-client/blob/master/LICENSE
+ */
 namespace DtmClient\JsonRpc;
 
 use Hyperf\Rpc\Contract\PathGeneratorInterface;
@@ -8,9 +14,6 @@ class DtmPatchGenerator implements PathGeneratorInterface
 {
     public function generate(string $service, string $method): string
     {
-        var_dump($service, $method);
-        var_dump('DtmPatchGenerator::generate');
-        var_dump('---------------');
-        return sprintf('%s.%s', $service, $method);
+        return $method;
     }
 }

--- a/src/JsonRpc/JsonRpcClient.php
+++ b/src/JsonRpc/JsonRpcClient.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of DTM-PHP.
+ *
+ * @license  https://github.com/dtm-php/dtm-client/blob/master/LICENSE
+ */
+namespace DtmClient\JsonRpc;
+
+use Hyperf\Contract\IdGeneratorInterface;
+use Hyperf\LoadBalancer\LoadBalancerManager;
+use Hyperf\Rpc\Protocol;
+use Hyperf\Rpc\ProtocolManager;
+use Hyperf\RpcClient\AbstractServiceClient;
+use Hyperf\RpcClient\Client;
+use Hyperf\RpcClient\Exception\RequestException;
+use Psr\Container\ContainerInterface;
+
+class JsonRpcClient extends AbstractServiceClient
+{
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    public function initClient()
+    {
+        $this->loadBalancerManager = $this->container->get(LoadBalancerManager::class);
+        $protocol = new Protocol($this->container, $this->container->get(ProtocolManager::class), $this->protocol, $this->getOptions());
+        $loadBalancer = $this->createLoadBalancer(...$this->createNodes());
+        $transporter = $protocol->getTransporter()->setLoadBalancer($loadBalancer);
+        $this->client = make(Client::class)
+            ->setPacker($protocol->getPacker())
+            ->setTransporter($transporter);
+        $this->idGenerator = $this->getIdGenerator();
+        $this->pathGenerator = $protocol->getPathGenerator();
+        $this->dataFormatter = $protocol->getDataFormatter();
+        return $this;
+    }
+
+    public function setServiceName(string $serviceName)
+    {
+        $this->serviceName = $serviceName;
+        return $this;
+    }
+
+    public function send(string $method, array $params, ?string $id = null)
+    {
+        if (! $id && $this->idGenerator instanceof IdGeneratorInterface) {
+            $id = $this->idGenerator->generate();
+        }
+        $response = $this->client->send($this->__generateData($method, $params, $id));
+        if (is_array($response)) {
+            $response = $this->checkRequestIdAndTryAgain($response, $id);
+
+            if (array_key_exists('result', $response) || array_key_exists('error', $response)) {
+                return $response;
+            }
+        }
+        throw new RequestException('Invalid response.');
+    }
+}

--- a/src/JsonRpc/JsonRpcClientManager.php
+++ b/src/JsonRpc/JsonRpcClientManager.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DtmClient\JsonRpc;
+
+class JsonRpcClientManager
+{
+
+}

--- a/src/JsonRpc/JsonRpcClientManager.php
+++ b/src/JsonRpc/JsonRpcClientManager.php
@@ -1,8 +1,26 @@
 <?php
 
+declare(strict_types=1);
+/**
+ * This file is part of DTM-PHP.
+ *
+ * @license  https://github.com/dtm-php/dtm-client/blob/master/LICENSE
+ */
 namespace DtmClient\JsonRpc;
 
 class JsonRpcClientManager
 {
+    /**
+     * @var JsonRpcClient[]
+     */
+    protected array $clients = [];
 
+    public function getClient(string $serviceName): JsonRpcClient
+    {
+        if (isset($this->clients[$serviceName])) {
+            return $this->clients[$serviceName];
+        }
+
+        return $this->clients[$serviceName] = make(JsonRpcClient::class)->setServiceName($serviceName)->initClient();
+    }
 }

--- a/src/Middleware/DtmMiddleware.php
+++ b/src/Middleware/DtmMiddleware.php
@@ -36,7 +36,7 @@ class DtmMiddleware implements MiddlewareInterface
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $queryParams = $request->getQueryParams();
+        $queryParams = $request->getQueryParams() ?: $request->getParsedBody();
         $transType = $queryParams['trans_type'] ?? null;
         $gid = $queryParams['gid'] ?? null;
         $branchId = $queryParams['branch_id'] ?? null;

--- a/src/MySqlBarrier.php
+++ b/src/MySqlBarrier.php
@@ -13,7 +13,6 @@ use DtmClient\Constants\Operation;
 use DtmClient\Constants\TransType;
 use DtmClient\DbTransaction\DBTransactionInterface;
 use DtmClient\Exception\DuplicatedException;
-use Hyperf\DbConnection\Db;
 
 class MySqlBarrier implements BarrierInterface
 {

--- a/src/TCC.php
+++ b/src/TCC.php
@@ -101,6 +101,24 @@ class TCC extends AbstractTransaction
                 ];
                 $this->api->transRequestBranch($branchRequest);
                 break;
+            case Protocol::JSONRPC_HTTP:
+                $this->api->registerBranch([
+                    'data' => json_encode($body),
+                    'branch_id' => $branchId,
+                    'confirm' => $confirmUrl,
+                    'cancel' => $cancelUrl,
+                    'gid' => TransContext::getGid(),
+                    'trans_type' => TransType::TCC,
+                ]);
+
+                $branchRequest = new RequestBranch();
+                $branchRequest->method = 'POST';
+                $branchRequest->url = $tryUrl;
+                $branchRequest->branchId = $branchId;
+                $branchRequest->op = Operation::TRY;
+                $branchRequest->body = $body;
+                return $this->api->transRequestBranch($branchRequest);
+                break;
             default:
                 throw new UnsupportedException('Unsupported protocol');
                 break;


### PR DESCRIPTION
支持 json-rpc-http 协议

- 由于原先 `hyperf` `json-rpc-http` 是不支持 `path` 的，所以需要等该pr完成后才能实现，[json-rpc-http support path](https://github.com/hyperf/hyperf/pull/4561)