### PR TITLE
适配hyperf3.0

### DIFF
--- a/src/Api/JsonRpcHttpApi.php
+++ b/src/Api/JsonRpcHttpApi.php
@@ -24,9 +24,9 @@ use Psr\Container\ContainerInterface;
 
 class JsonRpcHttpApi extends AbstractServiceClient implements ApiInterface
 {
-    protected $serviceName = 'dtmserver';
+    protected string $serviceName = 'dtmserver';
 
-    protected $protocol = 'jsonrpc-http';
+    protected string $protocol = 'jsonrpc-http';
 
     protected ConfigInterface $config;
 


### PR DESCRIPTION
因hyperf3.0在AbstractServiceClient对serviceName、protocol增加了string类型的指定，同步修改JsonRpcHttpApi中的serviceName、protocol