### PR TITLE
[BUG]fix saga enableConcurrent without addBranchOrder bug

### DIFF
--- a/src/Saga.php
+++ b/src/Saga.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  *
  * @license  https://github.com/dtm-php/dtm-client/blob/master/LICENSE
  */
+
 namespace DtmClient;
 
 use DtmClient\Api\ApiInterface;
@@ -79,7 +80,7 @@ class Saga extends AbstractTransaction
         if ($this->concurrent) {
             TransContext::setCustomData(json_encode([
                 'concurrent' => $this->concurrent,
-                'orders' => $this->orders,
+                'orders' => $this->orders ?: null,
             ]));
         }
     }

--- a/tests/Cases/SagaTest.php
+++ b/tests/Cases/SagaTest.php
@@ -103,6 +103,19 @@ class SagaTest extends AbstractTestCase
         $this->assertTrue($concurrent);
     }
 
+    public function testEnableConcurrentWithoutAddBranchOrders()
+    {
+        $api = \Mockery::mock(ApiInterface::class);
+
+        $saga = new Saga($api);
+        $saga->enableConcurrent();
+
+        $ordersProperty = new \ReflectionProperty($saga, 'orders');
+        $ordersProperty->setAccessible(true);
+        $orders = $ordersProperty->getValue($saga);
+        $this->assertSame(null, $orders ?: null);
+    }
+
     public function testSubmit()
     {
         $api = \Mockery::mock(ApiInterface::class);


### PR DESCRIPTION
In saga mode, with concurrent enabled but without branch orders set. orders => [] will be sent to DTM which is imcompatible with golang struct. So just simply send orders => null when no orders get set.

type cSagaCustom struct {
	Orders     map[int][]int `json:"orders"`
	Concurrent bool          `json:"concurrent"`
	cOrders    map[int][]int
}